### PR TITLE
Add modded torches from More Torch Variants to block/item.properties

### DIFF
--- a/shaders/block.properties
+++ b/shaders/block.properties
@@ -358,9 +358,10 @@ block.12480=polished_blackstone_pressure_plate polished_blackstone_button
 block.10484=gilded_blackstone
 block.10488=lily_pad
 block.10492=twisting_vines_plant twisting_vines weeping_vines weeping_vines_plant warped_fungus crimson_fungus
-block.10496=torch
+block.10496=torch \
+quad-mstv-mtv:acacia_torch quad-mstv-mtv:bamboo_torch quad-mstv-mtv:birch_torch quad-mstv-mtv:cherry_torch quad-mstv-mtv:crimson_torch quad-mstv-mtv:dark_oak_torch quad-mstv-mtv:pale_oak_torch quad-mstv-mtv:jungle_torch quad-mstv-mtv:mangrove_torch quad-mstv-mtv:spruce_torch quad-mstv-mtv:warped_torch
 block.10497=wall_torch \
-mcwlights:oak_tiki_torch:lit=true mcwlights:birch_tiki_torch:lit=true mcwlights:spruce_tiki_torch:lit=true mcwlights:jungle_tiki_torch:lit=true mcwlights:acacia_tiki_torch:lit=true mcwlights:dark_oak_tiki_torch:lit=true mcwlights:crimson_tiki_torch:lit=true mcwlights:warped_tiki_torch:lit=true mcwlights:mangrove_tiki_torch:lit=true mcwlights:bamboo_tiki_torch:lit=true
+mcwlights:oak_tiki_torch:lit=true mcwlights:birch_tiki_torch:lit=true mcwlights:spruce_tiki_torch:lit=true mcwlights:jungle_tiki_torch:lit=true mcwlights:acacia_tiki_torch:lit=true mcwlights:dark_oak_tiki_torch:lit=true mcwlights:crimson_tiki_torch:lit=true mcwlights:warped_tiki_torch:lit=true mcwlights:mangrove_tiki_torch:lit=true mcwlights:bamboo_tiki_torch:lit=true quad-mstv-mtv:acacia_wall_torch quad-mstv-mtv:bamboo_wall_torch quad-mstv-mtv:birch_wall_torch quad-mstv-mtv:cherry_wall_torch quad-mstv-mtv:crimson_wall_torch quad-mstv-mtv:dark_oak_wall_torch quad-mstv-mtv:pale_oak_wall_torch quad-mstv-mtv:jungle_wall_torch quad-mstv-mtv:mangrove_wall_torch quad-mstv-mtv:spruce_wall_torch quad-mstv-mtv:warped_wall_torch
 block.10500=end_rod:facing=up end_rod:facing=down
 block.10501=end_rod:facing=east end_rod:facing=west
 block.10502=end_rod:facing=north end_rod:facing=south
@@ -370,9 +371,10 @@ block.10512=chorus_flower:age=5
 block.10516=furnace:lit=true
 block.10520=cactus
 block.10524=note_block jukebox
-block.10528=soul_torch
+block.10528=soul_torch \
+quad-mstv-mtv:acacia_soul_torch quad-mstv-mtv:bamboo_soul_torch quad-mstv-mtv:birch_soul_torch quad-mstv-mtv:cherry_soul_torch quad-mstv-mtv:crimson_soul_torch quad-mstv-mtv:dark_oak_soul_torch quad-mstv-mtv:pale_oak_soul_torch quad-mstv-mtv:jungle_soul_torch quad-mstv-mtv:mangrove_soul_torch quad-mstv-mtv:spruce_soul_torch quad-mstv-mtv:warped_soul_torch
 block.10529=soul_wall_torch \
-mcwlights:soul_oak_tiki_torch:lit=true mcwlights:soul_birch_tiki_torch:lit=true mcwlights:soul_spruce_tiki_torch:lit=true mcwlights:soul_jungle_tiki_torch:lit=true mcwlights:soul_acacia_tiki_torch:lit=true mcwlights:soul_dark_oak_tiki_torch:lit=true mcwlights:soul_crimson_tiki_torch:lit=true mcwlights:soul_warped_tiki_torch:lit=true mcwlights:soul_mangrove_tiki_torch:lit=true mcwlights:soul_bamboo_tiki_torch:lit=true
+mcwlights:soul_oak_tiki_torch:lit=true mcwlights:soul_birch_tiki_torch:lit=true mcwlights:soul_spruce_tiki_torch:lit=true mcwlights:soul_jungle_tiki_torch:lit=true mcwlights:soul_acacia_tiki_torch:lit=true mcwlights:soul_dark_oak_tiki_torch:lit=true mcwlights:soul_crimson_tiki_torch:lit=true mcwlights:soul_warped_tiki_torch:lit=true mcwlights:soul_mangrove_tiki_torch:lit=true mcwlights:soul_bamboo_tiki_torch:lit=true quad-mstv-mtv:acacia_soul_wall_torch quad-mstv-mtv:bamboo_soul_wall_torch quad-mstv-mtv:birch_soul_wall_torch quad-mstv-mtv:cherry_soul_wall_torch quad-mstv-mtv:crimson_soul_wall_torch quad-mstv-mtv:dark_oak_soul_wall_torch quad-mstv-mtv:pale_oak_soul_wall_torch quad-mstv-mtv:jungle_soul_wall_torch quad-mstv-mtv:mangrove_soul_wall_torch quad-mstv-mtv:spruce_soul_wall_torch quad-mstv-mtv:warped_soul_wall_torch
 block.10532=brown_mushroom_block
 block.10536=red_mushroom_block
 block.10540=mushroom_stem
@@ -398,10 +400,14 @@ block.10597=redstone_wire:power=6 redstone_wire:power=7 redstone_wire:power=8 re
 block.10598=redstone_wire:power=11 redstone_wire:power=12 redstone_wire:power=13 redstone_wire:power=14
 block.10599=redstone_wire:power=15
 block.10600=redstone_wire:power=0
-block.10604=redstone_torch:lit=false
-block.10605=redstone_wall_torch:lit=false
-block.12604=redstone_torch:lit=true
-block.12605=redstone_wall_torch:lit=true
+block.10604=redstone_torch:lit=false \
+quad-mstv-mtv:acacia_redstone_torch:lit=false quad-mstv-mtv:bamboo_redstone_torch:lit=false quad-mstv-mtv:birch_redstone_torch:lit=false quad-mstv-mtv:cherry_redstone_torch:lit=false quad-mstv-mtv:crimson_redstone_torch:lit=false quad-mstv-mtv:dark_oak_redstone_torch:lit=false quad-mstv-mtv:pale_oak_redstone_torch:lit=false quad-mstv-mtv:jungle_redstone_torch:lit=false quad-mstv-mtv:mangrove_redstone_torch:lit=false quad-mstv-mtv:spruce_redstone_torch:lit=false quad-mstv-mtv:warped_redstone_torch:lit=false
+block.10605=redstone_wall_torch:lit=false \
+quad-mstv-mtv:acacia_redstone_wall_torch:lit=false quad-mstv-mtv:bamboo_redstone_wall_torch:lit=false quad-mstv-mtv:birch_redstone_wall_torch:lit=false quad-mstv-mtv:cherry_redstone_wall_torch:lit=false quad-mstv-mtv:crimson_redstone_wall_torch:lit=false quad-mstv-mtv:dark_oak_redstone_wall_torch:lit=false quad-mstv-mtv:pale_oak_redstone_wall_torch:lit=false quad-mstv-mtv:jungle_redstone_wall_torch:lit=false quad-mstv-mtv:mangrove_redstone_wall_torch:lit=false quad-mstv-mtv:spruce_redstone_wall_torch:lit=false quad-mstv-mtv:warped_redstone_wall_torch:lit=false
+block.12604=redstone_torch:lit=true  \
+quad-mstv-mtv:acacia_redstone_torch:lit=true quad-mstv-mtv:bamboo_redstone_torch:lit=true quad-mstv-mtv:birch_redstone_torch:lit=true quad-mstv-mtv:cherry_redstone_torch:lit=true quad-mstv-mtv:crimson_redstone_torch:lit=true quad-mstv-mtv:dark_oak_redstone_torch:lit=true quad-mstv-mtv:pale_oak_redstone_torch:lit=true quad-mstv-mtv:jungle_redstone_torch:lit=true quad-mstv-mtv:mangrove_redstone_torch:lit=true quad-mstv-mtv:spruce_redstone_torch:lit=true quad-mstv-mtv:warped_redstone_torch:lit=true
+block.12605=redstone_wall_torch:lit=true  \
+quad-mstv-mtv:acacia_redstone_wall_torch:lit=true quad-mstv-mtv:bamboo_redstone_wall_torch:lit=true quad-mstv-mtv:birch_redstone_wall_torch:lit=true quad-mstv-mtv:cherry_redstone_wall_torch:lit=true quad-mstv-mtv:crimson_redstone_wall_torch:lit=true quad-mstv-mtv:dark_oak_redstone_wall_torch:lit=true quad-mstv-mtv:pale_oak_redstone_wall_torch:lit=true quad-mstv-mtv:jungle_redstone_wall_torch:lit=true quad-mstv-mtv:mangrove_redstone_wall_torch:lit=true quad-mstv-mtv:spruce_redstone_wall_torch:lit=true quad-mstv-mtv:warped_redstone_wall_torch:lit=true
 block.10608=redstone_block
 block.10612=redstone_ore:lit=false
 block.10616=redstone_ore:lit=true

--- a/shaders/item.properties
+++ b/shaders/item.properties
@@ -6,13 +6,16 @@ item.40004=filled_map
 # itemID / 16  % 16: green
 # itemID / 256 % 16: blue
 
-item.15=redstone_block redstone_torch redstone_ore
+item.15=redstone_block redstone_torch redstone_ore \
+quad-mstv-mtv:acacia_redstone_torch quad-mstv-mtv:bamboo_redstone_torch quad-mstv-mtv:birch_redstone_torch quad-mstv-mtv:cherry_redstone_torch quad-mstv-mtv:crimson_redstone_torch quad-mstv-mtv:dark_oak_redstone_torch quad-mstv-mtv:pale_oak_redstone_torch quad-mstv-mtv:jungle_redstone_torch quad-mstv-mtv:mangrove_redstone_torch quad-mstv-mtv:spruce_redstone_torch quad-mstv-mtv:warped_redstone_torch
 item.79=magma_block magma_cream
-item.927=torch campfire lantern candle glowstone
+item.927=torch campfire lantern candle glowstone \
+quad-mstv-mtv:acacia_torch quad-mstv-mtv:bamboo_torch quad-mstv-mtv:birch_torch quad-mstv-mtv:cherry_torch quad-mstv-mtv:crimson_torch quad-mstv-mtv:dark_oak_torch quad-mstv-mtv:pale_oak_torch quad-mstv-mtv:jungle_torch quad-mstv-mtv:mangrove_torch quad-mstv-mtv:spruce_torch quad-mstv-mtv:warped_torch
 item.383=lava_bucket fire_charge shroomlight jack_o_lantern
 item.1267=emerald_block
 item.2295=sea_pickle
 item.3852=respawn_anchor crying_obsidian
 item.3902=amethyst_shard small_amethyst_bud medium_amethyst_bud large_amethyst_bud amethyst_cluster amethyst_block
 item.3920=blue_ice
-item.4037=soul_torch soul_campfire soul_lantern
+item.4037=soul_torch soul_campfire soul_lantern \
+quad-mstv-mtv:acacia_soul_torch quad-mstv-mtv:bamboo_soul_torch quad-mstv-mtv:birch_soul_torch quad-mstv-mtv:cherry_soul_torch quad-mstv-mtv:crimson_soul_torch quad-mstv-mtv:dark_oak_soul_torch quad-mstv-mtv:pale_oak_soul_torch quad-mstv-mtv:jungle_soul_torch quad-mstv-mtv:mangrove_soul_torch quad-mstv-mtv:spruce_soul_torch quad-mstv-mtv:warped_soul_torch


### PR DESCRIPTION
As the torches are just retextured vanilla torches, I added them to the same block id where I was able to find their respective vanilla counterpart.